### PR TITLE
chore(renovate): migrate renovate.json → .renovaterc.json5

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>LukeEvansTech/renovate-config"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>LukeEvansTech/renovate-config"]
-}


### PR DESCRIPTION
Renames the Renovate config file for fleet consistency (`.renovaterc.json5` is the house-standard filename).

- **Content unchanged** — still extends `github>LukeEvansTech/renovate-config` plus any existing repo-specific overrides.
- Validated with `renovate-config-validator`.

Config-only; no change to dependency-update behavior.