### PR TITLE
fix(ci): exclude vendored theme and devcontainer JSONC from super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -52,3 +52,18 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Two exclusions, both third-party/spec-mandated content we do not author:
+          #
+          # themes/ — the vendored vixcon-hugo theme. Upstream ships CRLF line
+          #   endings, which yamllint reports as a hard error ("wrong new line
+          #   character") in exampleSite/.forestry/settings.yml, plus a long tail of
+          #   indentation warnings. Reformatting a vendored theme would be
+          #   overwritten on the next theme update; it is not our code to style.
+          #   This mirrors the house default of skipping vendored/generated dirs.
+          #
+          # .devcontainer/devcontainer.json — JSONC, not JSON. The spec allows //
+          #   comments and the devcontainers templates ship them, but super-linter's
+          #   JSON validator parses strict JSON and fails "Parsing error: Unexpected
+          #   comment". Every devcontainer feature bump edits only this file, so
+          #   PRs #48 and #63 could never go green.
+          FILTER_REGEX_EXCLUDE: (^|/)themes/|(^|/)\.devcontainer/devcontainer\.json$


### PR DESCRIPTION
Unblocks all 3 open Renovate PRs. Both causes are third-party or spec-mandated content this repo doesn't author.

## 1. `themes/` — vendored vixcon-hugo theme

Upstream ships **CRLF**, which yamllint treats as a hard **error**:

```
themes/vixcon-hugo/exampleSite/.forestry/settings.yml:1:4: [error] wrong new line character
```

plus a long tail of indentation warnings. That single error is what failed `YAML` and `YAML_PRETTIER` on #54 — I verified the mechanism by running yamllint directly: **warnings alone exit 0, only errors exit non-zero**, and every finding in the run came from `themes/`.

Reformatting a vendored theme would be reverted by the next theme update — it isn't ours to style. Matches the house default of skipping vendored/generated dirs.

## 2. `.devcontainer/devcontainer.json` — JSONC, not JSON

The spec allows `//` comments and the devcontainers templates ship them; the JSON validator parses strict JSON and fails *"Parsing error: Unexpected comment"*. Devcontainer feature bumps edit **only** this file, so #48 and #63 had nothing else to lint and could never go green.

## Scope check

| path | result |
|---|---|
| `themes/vixcon-hugo/…/settings.yml` | excluded |
| `.devcontainer/devcontainer.json` | excluded |
| `.devcontainer/Dockerfile` | still linted |
| `.github/workflows/super-linter.yml` | still linted |
| `content/post/a.md`, `config.toml` | still linted |

`actionlint -shellcheck`: clean.

## Follow-ups not done here

- `mega-linter.yml` still present alongside super-linter (house standard removes MegaLinter).
- Calls standalone `github/super-linter@v7` (unpinned) rather than the shared reusable caller. Renovate PR #54 already pins the action.